### PR TITLE
Made it utf-8 friendly

### DIFF
--- a/htmlentities/__init__.py
+++ b/htmlentities/__init__.py
@@ -21,5 +21,5 @@ def decode(source):
     for entitie in re.findall('&(?:[a-z][a-z0-9]+);', source):
         entitie = entitie.replace('&', '')
         entitie = entitie.replace(';', '')
-        source = source.replace('&%s;' % entitie, chr(name2codepoint[entitie]))
+        source = source.replace('&%s;' % entitie, unichr(name2codepoint[entitie]))
     return source

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 from unittest import TestCase
 
 import htmlentities
@@ -9,3 +11,7 @@ class DecodingTestCase(TestCase):
         self.assertEqual('&', htmlentities.decode('&amp;'))
         self.assertEqual('"', htmlentities.decode('&quot;'))
         self.assertEqual('<', htmlentities.decode('&lt;'))
+
+    def test_should_decode_utf8_accents(self):
+        self.assertEqual(u'é', htmlentities.decode('&eacute;'))
+        self.assertEqual(u'ê', htmlentities.decode('&ecirc;'))

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 from unittest import TestCase
 
 import htmlentities
@@ -9,3 +11,7 @@ class EncodingTestCase(TestCase):
         self.assertEqual('&amp;', htmlentities.encode('&'))
         self.assertEqual('&quot;', htmlentities.encode('"'))
         self.assertEqual('&lt;', htmlentities.encode('<'))
+
+    def test_should_encode_utf8_accents(self):
+        self.assertEqual('&eacute;', htmlentities.encode(u'é'))
+        self.assertEqual('&ecirc;', htmlentities.encode(u'ê'))


### PR DESCRIPTION
As described in http://docs.python.org/library/htmllib.html#htmlentitydefs.name2codepoint name2codepoint store entities in utf-8, so, it should work with utf-8.
